### PR TITLE
Add ID response batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ And now to generate an ID:
 Optional<Id> id = icicleIdGenerator.generateId();
 ```
 
+Or a batch of IDs;
+
+```java
+Optional<List<Id>> ids = icicleIdGenerator.generateIdBatch(10); // Get up to 10 IDs
+Optional<List<Id>> ids = icicleIdGenerator.generateIdBatch(); // Get up to 4096 IDs
+```
+
+When requesting a batch of IDs, the generator cannot always return you the amount you asked for (this is a limitation related to our strong uniqueness guarantees) - instead, it will return between `1` and `n`, where `n` is the number of IDs you asked for in the batch. You may wish to check how many you actually received, and request more until you have the total you need.
+
 ### With Another Redis Library
 
 You can use Icicle with any Redis library you please. All you have to do is implement the `Redis` interface, and you can then use the `RoundRobinRedisPool` and `IcicleIdGenerator` classes as above with `icicle-jedis`.

--- a/icicle-core/src/main/java/com/intenthq/icicle/exception/InvalidBatchSizeException.java
+++ b/icicle-core/src/main/java/com/intenthq/icicle/exception/InvalidBatchSizeException.java
@@ -1,0 +1,10 @@
+package com.intenthq.icicle.exception;
+
+/**
+ * Exception thrown if the requested ID batch size is not within the minimum and maximum bounds.
+ */
+public class InvalidBatchSizeException extends RuntimeException {
+  public InvalidBatchSizeException(final String message) {
+    super(message);
+  }
+}

--- a/icicle-core/src/main/java/com/intenthq/icicle/redis/IcicleRedisResponse.java
+++ b/icicle-core/src/main/java/com/intenthq/icicle/redis/IcicleRedisResponse.java
@@ -12,7 +12,8 @@ import java.util.List;
  *
  * It has four fields, all equally important to generate an ID:
  *
- *   * The sequence
+ *   * Where sequence generation starts from
+ *   * Where sequence generation ends
  *   * The logical shard ID
  *   * The current time in seconds
  *   * The current time in microseconds
@@ -21,12 +22,14 @@ import java.util.List;
  * library.
  */
 public class IcicleRedisResponse {
-  private static final int SEQUENCE_INDEX = 0;
-  private static final int LOGICAL_SHARD_ID_INDEX = 1;
-  private static final int TIME_SECONDS_INDEX = 2;
-  private static final int TIME_MICROSECONDS_INDEX = 3;
+  private static final int START_SEQUENCE_INDEX = 0;
+  private static final int END_SEQUENCE_INDEX = 1;
+  private static final int LOGICAL_SHARD_ID_INDEX = 2;
+  private static final int TIME_SECONDS_INDEX = 3;
+  private static final int TIME_MICROSECONDS_INDEX = 4;
 
-  private final long sequence;
+  private final long startSequence;
+  private final long endSequence;
   private final long logicalShardId;
   private final long timeSeconds;
   private final long timeMicroseconds;
@@ -39,14 +42,19 @@ public class IcicleRedisResponse {
   public IcicleRedisResponse(final List<Long> results) {
     Preconditions.checkNotNull(results);
 
-    this.sequence = results.get(SEQUENCE_INDEX);
+    this.startSequence = results.get(START_SEQUENCE_INDEX);
+    this.endSequence = results.get(END_SEQUENCE_INDEX);
     this.logicalShardId = results.get(LOGICAL_SHARD_ID_INDEX);
     this.timeSeconds = results.get(TIME_SECONDS_INDEX);
     this.timeMicroseconds = results.get(TIME_MICROSECONDS_INDEX);
   }
 
-  public long getSequence() {
-    return sequence;
+  public long getStartSequence() {
+    return startSequence;
+  }
+
+  public long getEndSequence() {
+    return endSequence;
   }
 
   public long getLogicalShardId() {

--- a/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
+++ b/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
@@ -65,7 +65,7 @@ class JedisIcicleSpec extends Specification {
 
   "#evalLuaScript" should {
     val args = util.Arrays.asList("foo")
-    val response: java.util.List[java.lang.Long] = util.Arrays.asList(12L, 34L, 56L, 78L)
+    val response: java.util.List[java.lang.Long] = util.Arrays.asList(12L, 34L, 56L, 78L, 1L)
 
     "call to redis to eval the script with the given args" in new Context {
       val argsAsArray: Array[String] = args.toArray(Array[String]())

--- a/project/commons.scala
+++ b/project/commons.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object Commons {
-  val appVersion = "1.0.0"
+  val appVersion = "1.1.0"
 
   val pomInfo = (
     <url>https://github.com/intenthq/icicle</url>


### PR DESCRIPTION
Add functionality to request a batch of upto the maximum number of IDs generated per milisecond per node in a single request.
This allows us to request a huge number of unique IDs in one go, reducing the latency between requests when performing sequential processing over large batches.