### PR TITLE
Fix incorrect epoch start time, allow configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 out
 projectFilesBackup*
 target
+.idea

--- a/icicle-core/src/main/java/com/intenthq/icicle/Id.java
+++ b/icicle-core/src/main/java/com/intenthq/icicle/Id.java
@@ -32,4 +32,15 @@ public class Id {
   public String toString() {
     return Long.toString(id);
   }
+
+  public String toBinaryString() {
+    StringBuilder sb = new StringBuilder();
+
+    for(int i = 0; i < Long.numberOfLeadingZeros(id); i++) {
+      sb.append('0');
+    }
+
+    sb.append(Long.toBinaryString(id));
+    return sb.toString();
+  }
 }

--- a/icicle-core/src/test/scala/com/intenthq/icicle/IcicleIdGeneratorSpec.scala
+++ b/icicle-core/src/test/scala/com/intenthq/icicle/IcicleIdGeneratorSpec.scala
@@ -59,6 +59,18 @@ class IcicleIdGeneratorSpec extends Specification {
         (result.get.getTime must_== 1427291923000L)
     }
 
+    "construct the time portion of the ID as expected" in new Context {
+      redisResponse.getTimeSeconds returns 1401277473
+      redisResponse.getTimeMicroseconds returns 0
+      redis.evalLuaScript(any, any) returns Optional.of(redisResponse)
+
+      val result = underTest.generateId
+
+      (result.isPresent must beTrue) and
+        (result.get.getId must_== 3232200L) and
+        (result.get.getTime must_== 1427291923000L)
+    }
+
     "construct batch of IDs as expected" in new Context {
       redis.evalLuaScript(any, any) returns Optional.of(redisBatchResponse)
 
@@ -120,14 +132,14 @@ class IcicleIdGeneratorSpec extends Specification {
     val underTest = new IcicleIdGenerator(roundRobinRedisPool, 1)
 
     val redisResponse = mock[IcicleRedisResponse]
-    redisResponse.getTimeSeconds returns 1427291923
+    redisResponse.getTimeSeconds returns 1455787279
     redisResponse.getTimeMicroseconds returns 123
     redisResponse.getEndSequence returns 456
     redisResponse.getStartSequence returns 456
     redisResponse.getLogicalShardId returns 789
 
     val redisBatchResponse = mock[IcicleRedisResponse]
-    redisBatchResponse.getTimeSeconds returns 1427291923
+    redisBatchResponse.getTimeSeconds returns 1455787279
     redisBatchResponse.getTimeMicroseconds returns 123
     redisBatchResponse.getEndSequence returns 456
     redisBatchResponse.getStartSequence returns 0

--- a/project/commons.scala
+++ b/project/commons.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object Commons {
-  val appVersion = "1.1.1"
+  val appVersion = "2.0.0"
 
   val pomInfo = (
     <url>https://github.com/intenthq/icicle</url>


### PR DESCRIPTION
A mistake was made in the epoch start time. It was defined in seconds,
instead of milliseconds. As a result, the time component of previously
generated IDs was calculated incorrectly and the time period able to be
represented by the IDs was only possible via wrapping. As a result, the
epoch needs to be changed to be in the expected format so that the
guarantees hold.