### PR TITLE
Fix tests in master, upgrade all dependencies in prep for v2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 ---
 language: scala
 scala:
-  - 2.11.6
+  - 2.11.8
 script:
-  - sbt ++2.11.6 test
-  - sbt ++2.11.6 'it:test'
+  - sbt ++2.11.8 test
+  - sbt ++2.11.8 'it:test'
 services:
   - redis-server
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Intent HQ
+Copyright (c) 2015 - 2017 Intent HQ
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Implementations of Icicle could be written in any language using just a [Redis c
 
 ## Setup Your Redis Nodes
 
-You need to have some Redis nodes available and running to use with Icicle. They must be running Redis 2.6+ to have support for running Lua scripts. We recommend running at least 2 Redis nodes, allowing for redundancy and better performance.
+You need to have some Redis nodes available and running to use with Icicle. They must be running Redis 3.0+ to have support for running Lua scripts. We recommend running at least 2 Redis nodes, allowing for redundancy and better performance.
 
 Once you have the Redis servers up and running, **you must assign a logical shard ID to each Redis instance**. This is a unique number between 0 and 1023 (inclusive) that is assigned to each node to prevent duplicate IDs:
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Implementations of Icicle could be written in any language using just a [Redis c
 
 [Read more about Icicle on the Intent HQ Engineering blog](http://engineering.intenthq.com/2015/03/icicle-distributed-id-generation-with-redis-lua/).
 
+> **Icicle v1.x users:** There are some important breaking changes in v2.x! Please [read the release notes](https://github.com/intenthq/icicle/releases/tag/v2.0.0) for more information.
+
 ## Using Icicle
 
 ## Setup Your Redis Nodes
 
-You need to have some Redis nodes available and running to use with Icicle. They must be running Redis 3.0+ to have support for running Lua scripts. We recommend running at least 2 Redis nodes, allowing for redundancy and better performance.
+You need to have some Redis nodes available and running to use with Icicle. **Icicle works on Redis >= v2.6 as it requires Lua support.** Redis 3.x is supported and tested. We recommend running _at least_ 2 Redis nodes, allowing for redundancy and better performance.
 
 Once you have the Redis servers up and running, **you must assign a logical shard ID to each Redis instance**. This is a unique number between 0 and 1023 (inclusive) that is assigned to each node to prevent duplicate IDs:
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Commons._
 lazy val root: Project = Project(
   id        = "root",
   base      = file("."),
-  settings  = Project.defaultSettings ++ Seq(
+  settings  = Defaults.coreDefaultSettings ++ Seq(
     publishArtifact := false,
     publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
   ),
@@ -16,11 +16,11 @@ lazy val core = (project in file("icicle-core")).
   settings(Commons.settings: _*).
   settings(
     libraryDependencies ++= Seq(
-      "org.apache.commons" % "commons-lang3" % "3.0.1",
-      "commons-codec" % "commons-codec" % "1.9",
-      "org.slf4j" % "slf4j-simple" % "1.6.6",
-      "commons-io" % "commons-io" % "2.4",
-      "redis.clients" % "jedis" % "2.4.2" % "it,test"
+      "org.apache.commons" % "commons-lang3" % "3.5",
+      "commons-codec" % "commons-codec" % "1.10",
+      "org.slf4j" % "slf4j-simple" % "1.7.25",
+      "commons-io" % "commons-io" % "2.5",
+      "redis.clients" % "jedis" % "2.9.0" % "it,test"
     )
   )
 
@@ -30,7 +30,7 @@ lazy val jedis = (project in file("icicle-jedis")).
   settings(Commons.settings: _*).
   settings(
     libraryDependencies ++= Seq(
-      "com.google.code.findbugs" % "jsr305" % "2.0.3",
-      "redis.clients" % "jedis" % "2.4.2"
+      "com.google.code.findbugs" % "jsr305" % "3.0.1",
+      "redis.clients" % "jedis" % "2.9.0"
     )
   ).dependsOn(core)

--- a/icicle-core/src/it/scala/com/intenthq/icicle/IcicleIdGeneratorIntegrationSpec.scala
+++ b/icicle-core/src/it/scala/com/intenthq/icicle/IcicleIdGeneratorIntegrationSpec.scala
@@ -3,16 +3,13 @@ package com.intenthq.icicle
 import java.util
 
 import com.intenthq.icicle.redis.RoundRobinRedisPool
-import org.junit.runner.RunWith
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
-import org.specs2.runner.JUnitRunner
 import org.specs2.specification.Scope
 
 import scala.collection.JavaConversions._
 
-@RunWith(classOf[JUnitRunner])
 class IcicleIdGeneratorIntegrationSpec extends Specification {
   sequential
 

--- a/icicle-core/src/main/resources/id-generation.lua
+++ b/icicle-core/src/main/resources/id-generation.lua
@@ -8,7 +8,7 @@ local max_logical_shard_id = tonumber(KEYS[3])
 local num_ids = tonumber(KEYS[4])
 
 if redis.call('EXISTS', lock_key) == 1 then
-  redis.log(redis.LOG_INFO, 'Icicle: Cannot generate ID, waiting for lock to expire.')
+  redis.log(redis.LOG_NOTICE, 'Icicle: Cannot generate ID, waiting for lock to expire.')
   return redis.error_reply('Icicle: Cannot generate ID, waiting for lock to expire.')
 end
 
@@ -37,7 +37,7 @@ if end_sequence >= max_sequence then
   Note that it only blocks even it rolled around *not* in the same millisecond; this is because unless we do this, the
   IDs won't remain ordered.
   --]]
-  redis.log(redis.LOG_INFO, 'Icicle: Rolling sequence back to the start, locking for 1ms.')
+  redis.log(redis.LOG_NOTICE, 'Icicle: Rolling sequence back to the start, locking for 1ms.')
   redis.call('SET', sequence_key, '-1')
   redis.call('PSETEX', lock_key, 1, 'lock')
   end_sequence = max_sequence

--- a/icicle-core/src/test/scala/com/intenthq/icicle/IcicleIdGeneratorSpec.scala
+++ b/icicle-core/src/test/scala/com/intenthq/icicle/IcicleIdGeneratorSpec.scala
@@ -5,16 +5,13 @@ import java.util
 import com.google.common.base.Optional
 import com.intenthq.icicle.exception.{InvalidLogicalShardIdException, InvalidBatchSizeException}
 import com.intenthq.icicle.redis.{IcicleRedisResponse, Redis, RoundRobinRedisPool}
-import org.junit.runner.RunWith
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import org.specs2.specification.Scope
 
 import scala.collection.JavaConversions._
 
-@RunWith(classOf[JUnitRunner])
 class IcicleIdGeneratorSpec extends Specification {
   "#generateId" should {
     "retry a default of 5 times" in new Context {
@@ -55,20 +52,8 @@ class IcicleIdGeneratorSpec extends Specification {
       val result = underTest.generateId
 
       (result.isPresent must beTrue) and
-        (result.get.getId must_== 5980618838099710408L) and
-        (result.get.getTime must_== 1427291923000L)
-    }
-
-    "construct the time portion of the ID as expected" in new Context {
-      redisResponse.getTimeSeconds returns 1401277473
-      redisResponse.getTimeMicroseconds returns 0
-      redis.evalLuaScript(any, any) returns Optional.of(redisResponse)
-
-      val result = underTest.generateId
-
-      (result.isPresent must beTrue) and
-        (result.get.getId must_== 3232200L) and
-        (result.get.getTime must_== 1427291923000L)
+        (result.get.getId must_== 143322835047240136L) and
+        (result.get.getTime must_== 1489959427000L)
     }
 
     "construct batch of IDs as expected" in new Context {
@@ -132,14 +117,14 @@ class IcicleIdGeneratorSpec extends Specification {
     val underTest = new IcicleIdGenerator(roundRobinRedisPool, 1)
 
     val redisResponse = mock[IcicleRedisResponse]
-    redisResponse.getTimeSeconds returns 1455787279
+    redisResponse.getTimeSeconds returns 1489959427
     redisResponse.getTimeMicroseconds returns 123
     redisResponse.getEndSequence returns 456
     redisResponse.getStartSequence returns 456
     redisResponse.getLogicalShardId returns 789
 
     val redisBatchResponse = mock[IcicleRedisResponse]
-    redisBatchResponse.getTimeSeconds returns 1455787279
+    redisBatchResponse.getTimeSeconds returns 1489959427
     redisBatchResponse.getTimeMicroseconds returns 123
     redisBatchResponse.getEndSequence returns 456
     redisBatchResponse.getStartSequence returns 0

--- a/icicle-core/src/test/scala/com/intenthq/icicle/redis/RoundRobinRedisPoolSpec.scala
+++ b/icicle-core/src/test/scala/com/intenthq/icicle/redis/RoundRobinRedisPoolSpec.scala
@@ -2,14 +2,11 @@ package com.intenthq.icicle.redis
 
 import java.util
 
-import org.junit.runner.RunWith
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import org.specs2.specification.Scope
 
-@RunWith(classOf[JUnitRunner])
 class RoundRobinRedisPoolSpec extends Specification {
   "constructor" should {
     "throw exception if null list of servers given" in {

--- a/icicle-jedis/src/it/scala/com/intenthq/icicle/JedisIcicleIntegrationSpec.scala
+++ b/icicle-jedis/src/it/scala/com/intenthq/icicle/JedisIcicleIntegrationSpec.scala
@@ -1,10 +1,7 @@
 package com.intenthq.icicle
 
-import org.junit.runner.RunWith
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 class JedisIcicleIntegrationSpec extends Specification {
   "constructor" should {
     "sets the correct host and port if a valid host and port is passed" in {

--- a/icicle-jedis/src/main/java/com/intenthq/icicle/JedisIcicle.java
+++ b/icicle-jedis/src/main/java/com/intenthq/icicle/JedisIcicle.java
@@ -121,11 +121,11 @@ public class JedisIcicle implements Redis {
 
     try {
       T result = callback.apply(jedis);
-      jedisPool.returnResource(jedis);
       return result;
     } catch (Exception e) {
-      jedisPool.returnBrokenResource(jedis);
       throw e;
+    } finally {
+      jedis.close();
     }
   }
 }

--- a/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
+++ b/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
@@ -6,14 +6,11 @@ import _root_.redis.clients.jedis.exceptions.JedisDataException
 import _root_.redis.clients.jedis.{Jedis, JedisPool}
 import com.google.common.base.Optional
 import com.intenthq.icicle.redis.IcicleRedisResponse
-import org.junit.runner.RunWith
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
-import org.specs2.runner.JUnitRunner
 import org.specs2.specification.Scope
 
-@RunWith(classOf[JUnitRunner])
 class JedisIcicleSpec extends Specification {
   val luaScript = "foo"
   val sha = "abcdef1234567890"

--- a/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
+++ b/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
@@ -37,10 +37,10 @@ class JedisIcicleSpec extends Specification {
     "returns the resource if the call was successful" in new Context {
       underTest.loadLuaScript("foo")
 
-      there was one(jedisPool).returnResource(jedis)
+      there was one(jedis).close()
     }
 
-    "returns the resource as failed if the call threw an exception" in new Context {
+    "returns the resource if the call threw an exception" in new Context {
       jedis.scriptLoad(luaScript) throws new RuntimeException
 
       try {
@@ -49,7 +49,7 @@ class JedisIcicleSpec extends Specification {
         case e: RuntimeException => null
       }
 
-      there was one(jedisPool).returnBrokenResource(jedis)
+      there was one(jedis).close()
     }
 
     "rethrows any exception the call throws" in new Context {
@@ -91,10 +91,10 @@ class JedisIcicleSpec extends Specification {
 
       underTest.evalLuaScript(sha, args)
 
-      there was one(jedisPool).returnResource(jedis)
+      there was one(jedis).close()
     }
 
-    "returns the resource as failed if the call threw an exception" in new Context {
+    "returns the resource if the call threw an exception" in new Context {
       jedis.evalsha(any, any, anyString) throws new RuntimeException
 
       try {
@@ -103,7 +103,7 @@ class JedisIcicleSpec extends Specification {
         case e: RuntimeException => null
       }
 
-      there was one(jedisPool).returnBrokenResource(jedis)
+      there was one(jedis).close()
     }
 
     "rethrows any exception the call throws" in new Context {

--- a/project/commons.scala
+++ b/project/commons.scala
@@ -26,7 +26,7 @@ object Commons {
   )
 
   val settings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
-    scalaVersion := "2.11.6",
+    scalaVersion := "2.11.8",
     organization := "com.intenthq.icicle",
     version := appVersion,
     publishMavenStyle := true,
@@ -34,7 +34,6 @@ object Commons {
     autoScalaLibrary := false,
     publishArtifact in Test := false,
     pomIncludeRepository := { _ => false },
-    resolvers += "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases",
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
       if (isSnapshot.value)
@@ -45,8 +44,9 @@ object Commons {
     pomExtra := pomInfo,
     resolvers += Opts.resolver.mavenLocalFile,
     libraryDependencies ++= Seq(
-      "com.google.guava" % "guava" % "17.0",
-      "org.specs2" %% "specs2" % "2.4.17" % "it,test"
+      "com.google.guava" % "guava" % "21.0",
+      "org.specs2" %% "specs2-core" % "3.8.9" % "it,test",
+      "org.specs2" %% "specs2-mock" % "3.8.9" % "it,test"
     )
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")


### PR DESCRIPTION
This fixes #19, and gets us one step closer to cutting the v2.0 release
because we are now working on Redis v3.0+, which fixes #20.