### PR TITLE
Use Java 8 features, remove unnecessary dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: scala
 scala:
   - 2.11.8
 script:
-  - sbt ++2.11.8 test
-  - sbt ++2.11.8 'it:test'
+  - sbt ++2.11.8 test 'it:test'
 services:
   - redis-server
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,20 @@ language: scala
 scala:
   - 2.11.8
 script:
+  - jdk_switcher use oraclejdk8
   - sbt ++2.11.8 test 'it:test'
 services:
   - redis-server
-jdk:
-  - oraclejdk8
+# FIXME: Version of Java 8 is (as of writing this) 1.8.0_31-b13. This does not
+# contain the important fix from https://bugs.openjdk.java.net/browse/JDK-8043926
+# which otherwise means certain type bounds don't work.
+#
+# We follow the advice from https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-243534696
+# to fix this below.
+# jdk:
+#   - oraclejdk8
+sudo: false
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import Commons._
 
+scalaVersion in ThisBuild := "2.11.8"
+
 lazy val root: Project = Project(
   id        = "root",
   base      = file("."),
@@ -16,10 +18,8 @@ lazy val core = (project in file("icicle-core")).
   settings(Commons.settings: _*).
   settings(
     libraryDependencies ++= Seq(
-      "org.apache.commons" % "commons-lang3" % "3.5",
       "commons-codec" % "commons-codec" % "1.10",
-      "org.slf4j" % "slf4j-simple" % "1.7.25",
-      "commons-io" % "commons-io" % "2.5",
+      "org.slf4j" % "slf4j-api" % "1.7.25",
       "redis.clients" % "jedis" % "2.9.0" % "it,test"
     )
   )
@@ -30,7 +30,6 @@ lazy val jedis = (project in file("icicle-jedis")).
   settings(Commons.settings: _*).
   settings(
     libraryDependencies ++= Seq(
-      "com.google.code.findbugs" % "jsr305" % "3.0.1",
       "redis.clients" % "jedis" % "2.9.0"
     )
   ).dependsOn(core)

--- a/icicle-core/src/it/java/com/intenthq/icicle/TestRedis.java
+++ b/icicle-core/src/it/java/com/intenthq/icicle/TestRedis.java
@@ -1,11 +1,10 @@
 package com.intenthq.icicle;
 
-import com.google.common.base.Optional;
-
 import com.intenthq.icicle.redis.IcicleRedisResponse;
 import com.intenthq.icicle.redis.Redis;
 
 import java.util.List;
+import java.util.Optional;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisDataException;
@@ -39,7 +38,7 @@ public class TestRedis implements Redis {
       List<Long> results = (List<Long>) jedis.evalsha(luaScriptSha, arguments.size(), args);
       return Optional.of(new IcicleRedisResponse(results));
     } catch (JedisDataException e) {
-      return Optional.absent();
+      return Optional.empty();
     }
   }
 }

--- a/icicle-core/src/main/java/com/intenthq/icicle/redis/IcicleRedisResponse.java
+++ b/icicle-core/src/main/java/com/intenthq/icicle/redis/IcicleRedisResponse.java
@@ -1,11 +1,7 @@
 package com.intenthq.icicle.redis;
 
-import com.google.common.base.Preconditions;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The response from the Icicle ID generation script.
@@ -40,8 +36,6 @@ public class IcicleRedisResponse {
    *                will be thrown.
    */
   public IcicleRedisResponse(final List<Long> results) {
-    Preconditions.checkNotNull(results);
-
     this.startSequence = results.get(START_SEQUENCE_INDEX);
     this.endSequence = results.get(END_SEQUENCE_INDEX);
     this.logicalShardId = results.get(LOGICAL_SHARD_ID_INDEX);
@@ -70,10 +64,19 @@ public class IcicleRedisResponse {
   }
 
   public boolean equals(final Object o) {
-    return EqualsBuilder.reflectionEquals(this, o);
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+
+    IcicleRedisResponse response = (IcicleRedisResponse) o;
+    return Objects.equals(startSequence, response.getStartSequence())
+      && Objects.equals(endSequence, response.getEndSequence())
+      && Objects.equals(logicalShardId, response.getLogicalShardId())
+      && Objects.equals(timeSeconds, response.getTimeSeconds())
+      && Objects.equals(timeMicroseconds, response.getTimeMicroseconds());
   }
 
   public int hashCode() {
-    return HashCodeBuilder.reflectionHashCode(this);
+    return Objects.hash(startSequence, endSequence, logicalShardId, timeSeconds, timeMicroseconds);
   }
 }

--- a/icicle-core/src/main/java/com/intenthq/icicle/redis/Redis.java
+++ b/icicle-core/src/main/java/com/intenthq/icicle/redis/Redis.java
@@ -1,8 +1,7 @@
 package com.intenthq.icicle.redis;
 
-import com.google.common.base.Optional;
-
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This interface defines operations that the ID generator needs in order to be able to work. The most common Redis

--- a/icicle-core/src/main/java/com/intenthq/icicle/redis/RoundRobinRedisPool.java
+++ b/icicle-core/src/main/java/com/intenthq/icicle/redis/RoundRobinRedisPool.java
@@ -1,7 +1,5 @@
 package com.intenthq.icicle.redis;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Iterator;
 import java.util.List;
 
@@ -22,8 +20,9 @@ public class RoundRobinRedisPool {
    * @param redisServers A list of redis servers to use.
    */
   public RoundRobinRedisPool(final List<Redis> redisServers) {
-    Preconditions.checkNotNull(redisServers);
-    Preconditions.checkArgument(redisServers.size() > 0);
+    if (redisServers.isEmpty()) {
+      throw new IllegalArgumentException("Given list of redis servers is empty.");
+    }
 
     this.redisServers = redisServers;
     this.redisPoolIterator = redisServers.iterator();

--- a/icicle-core/src/test/scala/com/intenthq/icicle/IcicleIdGeneratorSpec.scala
+++ b/icicle-core/src/test/scala/com/intenthq/icicle/IcicleIdGeneratorSpec.scala
@@ -1,9 +1,9 @@
 package com.intenthq.icicle
 
 import java.util
+import java.util.Optional
 
-import com.google.common.base.Optional
-import com.intenthq.icicle.exception.{InvalidLogicalShardIdException, InvalidBatchSizeException}
+import com.intenthq.icicle.exception.{InvalidBatchSizeException, InvalidLogicalShardIdException}
 import com.intenthq.icicle.redis.{IcicleRedisResponse, Redis, RoundRobinRedisPool}
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito
@@ -15,7 +15,7 @@ import scala.collection.JavaConversions._
 class IcicleIdGeneratorSpec extends Specification {
   "#generateId" should {
     "retry a default of 5 times" in new Context {
-      redis.evalLuaScript(any, any) returns Optional.absent[IcicleRedisResponse]
+      redis.evalLuaScript(any, any) returns Optional.empty[IcicleRedisResponse]
       new IcicleIdGenerator(roundRobinRedisPool).generateId
 
       // The number is double because if the eval fails the first time it loads and tries to eval again.
@@ -23,15 +23,15 @@ class IcicleIdGeneratorSpec extends Specification {
     }
 
     "retry `maximumAttempts` times if passed" in new Context {
-      redis.evalLuaScript(any, any) returns Optional.absent[IcicleRedisResponse]
+      redis.evalLuaScript(any, any) returns Optional.empty[IcicleRedisResponse]
       new IcicleIdGenerator(roundRobinRedisPool, 10).generateId
 
       // The number is double because if the eval fails the first time it loads and tries to eval again.
       there were exactly(20)(redis).evalLuaScript(any, any)
     }
 
-    "return an absent optional if `maximumAttempts` is exceeded" in new Context {
-      redis.evalLuaScript(any, any) returns Optional.absent[IcicleRedisResponse]
+    "return an empty optional if `maximumAttempts` is exceeded" in new Context {
+      redis.evalLuaScript(any, any) returns Optional.empty[IcicleRedisResponse]
 
       val result = underTest.generateId
 
@@ -89,7 +89,7 @@ class IcicleIdGeneratorSpec extends Specification {
     }
 
     "load the lua script if not already loaded" in new Context {
-      redis.evalLuaScript(any, any) returns Optional.absent[IcicleRedisResponse]
+      redis.evalLuaScript(any, any) returns Optional.empty[IcicleRedisResponse]
 
       underTest.generateId
 
@@ -97,7 +97,7 @@ class IcicleIdGeneratorSpec extends Specification {
     }
 
     "return an optional with ID even if the script had to be loaded" in new Context {
-      redis.evalLuaScript(any, any) returns Optional.absent[IcicleRedisResponse] thenReturn Optional.of(redisResponse)
+      redis.evalLuaScript(any, any) returns Optional.empty[IcicleRedisResponse] thenReturn Optional.of(redisResponse)
 
       val result = underTest.generateId
 
@@ -105,7 +105,7 @@ class IcicleIdGeneratorSpec extends Specification {
     }
 
     "fail if loading the script fails twice" in new Context {
-      redis.evalLuaScript(any, any) returns Optional.absent[IcicleRedisResponse]
+      redis.evalLuaScript(any, any) returns Optional.empty[IcicleRedisResponse]
 
       underTest.generateId.isPresent must beFalse
     }

--- a/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
+++ b/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
@@ -1,10 +1,10 @@
 package com.intenthq.icicle
 
 import java.util
+import java.util.Optional
 
 import _root_.redis.clients.jedis.exceptions.JedisDataException
 import _root_.redis.clients.jedis.{Jedis, JedisPool}
-import com.google.common.base.Optional
 import com.intenthq.icicle.redis.IcicleRedisResponse
 import org.specs2.matcher.ThrownExpectations
 import org.specs2.mock.Mockito

--- a/project/commons.scala
+++ b/project/commons.scala
@@ -44,7 +44,6 @@ object Commons {
     pomExtra := pomInfo,
     resolvers += Opts.resolver.mavenLocalFile,
     libraryDependencies ++= Seq(
-      "com.google.guava" % "guava" % "21.0",
       "org.specs2" %% "specs2-core" % "3.8.9" % "it,test",
       "org.specs2" %% "specs2-mock" % "3.8.9" % "it,test"
     )


### PR DESCRIPTION
In preparation for v2.0, I have noticed that a significant amount of our
dependencies aren't actually necessary at all. The list:

* Guava, can be entirely replaced with Java 8 features.
* Commons IO, can be replaced entirely with NIO.
* Commons Lang, handroll an equals and hash method using Java's
  `Objects` utils.
* SLF4J should be using `slf4j-api`, not `slf4j-simple`, as this is
  really bad practice for libraries to import an actual logger.
* Findbugs, annotations not used anymore.