### PR TITLE
Make sure loading Lua from resources works.

### DIFF
--- a/icicle-core/src/it/scala/com/intenthq/icicle/IcicleIdGeneratorIntegrationSpec.scala
+++ b/icicle-core/src/it/scala/com/intenthq/icicle/IcicleIdGeneratorIntegrationSpec.scala
@@ -10,7 +10,7 @@ import org.specs2.specification.Scope
 
 import scala.collection.JavaConversions._
 
-class IcicleIdGeneratorIntegrationSpec extends Specification {
+object IcicleIdGeneratorIntegrationSpec extends Specification {
   sequential
 
   "The IcicleIdGenerator" should {

--- a/icicle-core/src/test/scala/com/intenthq/icicle/IcicleIdGeneratorSpec.scala
+++ b/icicle-core/src/test/scala/com/intenthq/icicle/IcicleIdGeneratorSpec.scala
@@ -12,7 +12,7 @@ import org.specs2.specification.Scope
 
 import scala.collection.JavaConversions._
 
-class IcicleIdGeneratorSpec extends Specification {
+object IcicleIdGeneratorSpec extends Specification {
   "#generateId" should {
     "retry a default of 5 times" in new Context {
       redis.evalLuaScript(any, any) returns Optional.empty[IcicleRedisResponse]

--- a/icicle-core/src/test/scala/com/intenthq/icicle/redis/RoundRobinRedisPoolSpec.scala
+++ b/icicle-core/src/test/scala/com/intenthq/icicle/redis/RoundRobinRedisPoolSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import org.specs2.specification.Scope
 
-class RoundRobinRedisPoolSpec extends Specification {
+object RoundRobinRedisPoolSpec extends Specification {
   "constructor" should {
     "throw exception if null list of servers given" in {
       new RoundRobinRedisPool(null) must throwA[NullPointerException]

--- a/icicle-jedis/src/it/scala/com/intenthq/icicle/JedisIcicleIntegrationSpec.scala
+++ b/icicle-jedis/src/it/scala/com/intenthq/icicle/JedisIcicleIntegrationSpec.scala
@@ -1,15 +1,48 @@
 package com.intenthq.icicle
 
+import java.util
+
+import com.intenthq.icicle.redis.RoundRobinRedisPool
 import org.specs2.mutable._
 
-class JedisIcicleIntegrationSpec extends Specification {
+object JedisIcicleIntegrationSpec extends Specification {
   "constructor" should {
     "sets the correct host and port if a valid host and port is passed" in {
       val underTest = new JedisIcicle("localhost:6379")
       val jedis = underTest.getJedisPool.getResource
 
-      (jedis.getClient.getHost must_== "localhost") and
-        (jedis.getClient.getPort must_== 6379)
+      try {
+        (jedis.getClient.getHost must_== "localhost") and
+          (jedis.getClient.getPort must_== 6379)
+      } finally {
+        jedis.close()
+      }
     }
   }
+
+  "works with a real ID generator" in {
+    val jedisIcicle = new JedisIcicle("localhost:6379")
+    val roundRobinRedisPool = new RoundRobinRedisPool(util.Arrays.asList(jedisIcicle))
+    val idGenerator = new IcicleIdGenerator(roundRobinRedisPool)
+    val jedis = jedisIcicle.getJedisPool.getResource
+    try {
+      jedis.set(logicalShardIdRedisKey, "1")
+      jedis.del(sequenceRedisKey)
+    } finally {
+      jedis.close()
+    }
+
+    val n = 100000
+    val ids = (1 to n).map { _ => idGenerator.generateId() }
+
+    // They were all successful...
+    (ids.forall(_.isPresent) must beTrue) and
+      // They were all unique...
+      (ids.map(_.get).toSet.size must_== n) and
+      // And they were in order!
+      (ids.map(_.get).map(_.getId) must beSorted)
+  }
+
+  val sequenceRedisKey = "icicle-generator-sequence"
+  val logicalShardIdRedisKey = "icicle-generator-logical-shard-id"
 }

--- a/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
+++ b/icicle-jedis/src/test/scala/com/intenthq/icicle/JedisIcicleSpec.scala
@@ -11,7 +11,7 @@ import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import org.specs2.specification.Scope
 
-class JedisIcicleSpec extends Specification {
+object JedisIcicleSpec extends Specification {
   val luaScript = "foo"
   val sha = "abcdef1234567890"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/project/commons.scala
+++ b/project/commons.scala
@@ -46,6 +46,7 @@ object Commons {
     libraryDependencies ++= Seq(
       "org.specs2" %% "specs2-core" % "3.8.9" % "it,test",
       "org.specs2" %% "specs2-mock" % "3.8.9" % "it,test"
-    )
+    ),
+    exportJars := true
   )
 }


### PR DESCRIPTION
Unfortunately, the switch away from `IOUtils` has actually broken the
reading of the Lua script from resources when packed into an external
project.

Thankfully, Java 8 has ways now to read the resource as a stream and not
as a file without writing a billion lines of code, so we'll switch to
that.